### PR TITLE
pandera validation

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -10,7 +10,7 @@ logging:
 
 usgs:
   monitoring_locations:
-    base_url: "https://api.waterdata.usgs.gov/ogcapi/v0/collections/monitoring-locations/items?f=json"
+    base_url: "https://api.waterdata.usgs.gov/ogcapi/v0/collections/monitoring-locations/items"
     limit: 10000
     request_timeout: 10
     max_retries: 3
@@ -24,7 +24,7 @@ usgs:
     consistency_rules: ["geometry_requires_id"]
 
   daily_values:
-    base_url: "https://nwis.waterservices.usgs.gov/nwis/dv/?format=json"
+    base_url: "https://api.waterdata.usgs.gov/ogcapi/v0/collections/daily/items"
     limit: 10000
     request_timeout: 10
     max_retries: 3
@@ -38,12 +38,12 @@ usgs:
       time: parse_datetime
       last_modified: parse_datetime
       geometry: flatten_geometry
-    critical_fields: ["id", "value", "datetime"]
+    critical_fields: ["id", "geometry"]
     id_field: "id"
     consistency_rules: []
 
   parameter_codes:
-    base_url: "https://api.waterdata.usgs.gov/ogcapi/v0/collections/parameter-codes/items?f=json"
+    base_url: "https://api.waterdata.usgs.gov/ogcapi/v0/collections/parameter-codes/items"
     limit: 10000
     request_timeout: 10
     max_retries: 3
@@ -52,7 +52,7 @@ usgs:
     extra_params: {}
     transformations:
       geometry: flatten_geometry
-    critical_fields: ["id", "parameter_cd"]
+    critical_fields: ["id", "geometry"]
     id_field: "id"
     consistency_rules: []
 

--- a/src/models/schema_registry.py
+++ b/src/models/schema_registry.py
@@ -1,0 +1,14 @@
+##########################################################################################
+# models/schema_registry.py
+# Description: Maps each endpoint to its Pandera validator schema
+##########################################################################################
+
+from validators.usgs_daily_validator_schema import daily_schema
+from validators.usgs_monitoring_locations_validator_schema import monitoring_schema
+from validators.usgs_parameter_codes_validator_schema import parameter_codes_schema
+
+SCHEMA_REGISTRY = {
+    "daily_values": daily_schema,
+    "monitoring_locations": monitoring_schema,
+    "parameter_codes": parameter_codes_schema,
+}

--- a/src/models/usgs_daily_schema.py
+++ b/src/models/usgs_daily_schema.py
@@ -1,5 +1,5 @@
 ###########################################
-# Name: usgs_daily_values_schema.py
+# Name: usgs_daily_schema.py
 # Author: Christopher O. Romanillos
 # Description: SQLAlchemy ORM Schema for USGS Daily Values
 # Date: 09/01/25

--- a/src/models/validators/usgs_daily_validator_schema.py
+++ b/src/models/validators/usgs_daily_validator_schema.py
@@ -1,0 +1,26 @@
+###########################################
+# Name: usgs_daily_validator_schema.py
+# Author: Christopher O. Romanillos
+# Description: SQLAlchemy ORM Schema for USGS Daily Values
+# Date: 09/01/25
+###########################################
+
+import pandera as pa
+from pandera import Column, Check
+from datetime import datetime
+
+daily_schema = pa.DataFrameSchema({
+    "uuid": Column(pa.String, nullable=False),
+    "source_id": Column(pa.String, nullable=False),
+    "time_series_id": Column(pa.String, nullable=False),
+    "monitoring_location_id": Column(pa.String, nullable=False),
+    "parameter_code": Column(pa.String, nullable=False),
+    "statistic_id": Column(pa.String, nullable=False),
+    "time": Column(pa.DateTime, nullable=False),
+    "last_modified": Column(pa.DateTime, nullable=True),
+    "value": Column(pa.String, nullable=True),
+    "unit_of_measure": Column(pa.String, nullable=True),
+    "approval_status": Column(pa.String, nullable=True),
+    "qualifier": Column(pa.String, nullable=True),
+    "geometry": Column(pa.String, nullable=True),  # WKT/GeoJSON representation
+})

--- a/src/models/validators/usgs_monitoring_locations_validator_schema.py
+++ b/src/models/validators/usgs_monitoring_locations_validator_schema.py
@@ -1,0 +1,52 @@
+###########################################
+# Name: usgs_monitoring_locations_validator_schema.py
+# Author: Christopher O. Romanillos
+# Description: SQLAlchemy ORM Schema for USGS Monitoring Locations
+###########################################
+
+import pandera as pa
+from pandera import Column, Check
+
+monitoring_schema = pa.DataFrameSchema({
+    "id": Column(pa.String, nullable=False),
+    "agency_code": Column(pa.String, nullable=False),
+    "agency_name": Column(pa.String, nullable=True),
+    "monitoring_location_number": Column(pa.String, nullable=True),
+    "monitoring_location_name": Column(pa.String, nullable=True),
+    "district_code": Column(pa.String, nullable=True),
+    "country_code": Column(pa.String, nullable=True),
+    "country_name": Column(pa.String, nullable=True),
+    "state_code": Column(pa.String, nullable=True),
+    "state_name": Column(pa.String, nullable=True),
+    "county_code": Column(pa.String, nullable=True),
+    "county_name": Column(pa.String, nullable=True),
+    "minor_civil_division_code": Column(pa.String, nullable=True),
+    "site_type_code": Column(pa.String, nullable=True),
+    "site_type": Column(pa.String, nullable=True),
+    "hydrologic_unit_code": Column(pa.String, nullable=True),
+    "basin_code": Column(pa.String, nullable=True),
+    "altitude": Column(pa.Float, nullable=True),
+    "altitude_accuracy": Column(pa.Float, nullable=True),
+    "altitude_method_code": Column(pa.String, nullable=True),
+    "altitude_method_name": Column(pa.String, nullable=True),
+    "vertical_datum": Column(pa.String, nullable=True),
+    "vertical_datum_name": Column(pa.String, nullable=True),
+    "horizontal_positional_accuracy_code": Column(pa.String, nullable=True),
+    "horizontal_positional_accuracy": Column(pa.String, nullable=True),
+    "horizontal_position_method_code": Column(pa.String, nullable=True),
+    "horizontal_position_method_name": Column(pa.String, nullable=True),
+    "original_horizontal_datum": Column(pa.String, nullable=True),
+    "original_horizontal_datum_name": Column(pa.String, nullable=True),
+    "drainage_area": Column(pa.Float, nullable=True),
+    "contributing_drainage_area": Column(pa.Float, nullable=True),
+    "time_zone_abbreviation": Column(pa.String, nullable=True),
+    "uses_daylight_savings": Column(pa.Bool, nullable=True),
+    "construction_date": Column(pa.String, nullable=True),
+    "aquifer_code": Column(pa.String, nullable=True),
+    "national_aquifer_code": Column(pa.String, nullable=True),
+    "aquifer_type_code": Column(pa.String, nullable=True),
+    "well_constructed_depth": Column(pa.Float, nullable=True),
+    "hole_constructed_depth": Column(pa.Float, nullable=True),
+    "depth_source_code": Column(pa.String, nullable=True),
+    "geometry": Column(pa.String, nullable=True),
+})

--- a/src/models/validators/usgs_parameter_codes_validator_schema.py
+++ b/src/models/validators/usgs_parameter_codes_validator_schema.py
@@ -1,0 +1,26 @@
+############################################################
+# Name: usgs_parameter_codes_validator_schema.py
+# Author: Christopher O. Romanillos
+# Description: SQLAlchemy ORM Schema for USGS Parameter Codes
+# Date: 09/02/25
+#############################################################
+
+import pandera as pa
+from pandera import Column, Check
+
+parameter_codes_schema = pa.DataFrameSchema({
+    "id": Column(pa.String, nullable=False),
+    "parameter_name": Column(pa.String, nullable=True),
+    "unit_of_measure": Column(pa.String, nullable=True),
+    "parameter_group_code": Column(pa.String, nullable=True),
+    "parameter_description": Column(pa.String, nullable=True),
+    "medium": Column(pa.String, nullable=True),
+    "statistical_basis": Column(pa.String, nullable=True),
+    "time_basis": Column(pa.String, nullable=True),
+    "weight_basis": Column(pa.String, nullable=True),
+    "particle_size_basis": Column(pa.String, nullable=True),
+    "sample_fraction": Column(pa.String, nullable=True),
+    "temperature_basis": Column(pa.String, nullable=True),
+    "epa_equivalence": Column(pa.String, nullable=True),
+    "geometry": Column(pa.String, nullable=True),
+})


### PR DESCRIPTION
- validators/ created to house validation schemas for pandera; Catch errors any field mismatches earlier than in the DB layer.
- schema_registry created to avoid overhead of passing the correct schema/endpoint parameters
- usgs_validator.py script updated to use pandera in validation step
- Ultimately, we use pandera for schema validation, and SQLAlchemy for mapping the dataframe to the database (loading)